### PR TITLE
Use url-listener to handle push, pop, and hash events

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ For Rendering:
 
 For Routing:
   - [nanorouter](https://github.com/yoshuawuyts/nanorouter)
+  - [url-listener](https://github.com/JRJurman/url-listener)
 
 For State Management:
   - [yo-yo](https://github.com/maxogden/yo-yo)
@@ -236,7 +237,8 @@ const home = (state) => {
 ### `Tram.constructor([options])`
 `new Tram()` returns an instance of the Tram. The constructor
 takes in an `options` object, which can have a `defaultRoute`.
-By default, this is `/404`, but you can set it to whatever path
+
+`defaultRoute` by default is `/404`, but you can set it to whatever path
 you want to load when path matching fails.
 
 <details>
@@ -365,6 +367,19 @@ app.addRoute('/404', noPage)
 ```
 
 </details>
+
+### `app.dispatch(action)`
+_Reference: [minidux](https://github.com/freeman-lab/minidux)_
+
+**WARNING: EXPERIMENTAL METHOD**
+_This method is currently under discussion:
+https://github.com/JRJurman/tram-one/issues/8 ._
+
+`app.dispatch` will dispatch an action to the combined reducers. This should
+**only be used outside of components**. When inside of a component, you have
+access to `state.dispatch`. `app.dispatch` should only be used when you need to
+dispatch an action in testing.
+`action` should be an object with a property `type`.
 
 ### `app.start(selector, [pathName])`
 

--- a/examples/using-reducers/index.js
+++ b/examples/using-reducers/index.js
@@ -6,6 +6,7 @@ const app = new Tram()
 const html = Tram.html()
 
 const counterReducer = (state, action) => {
+  console.log(action)
   if (action.type === 'click') {
     return xtend(state, { clicks: state.clicks + 1 })
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "🚋 Batteries Included View Framework",
   "main": "dist/tram-one.esm.js",
   "browser": "dist/tram-one.umd.js",
@@ -33,6 +33,7 @@
     "minidux": "^1.0.1",
     "nanorouter": "^2.0.0",
     "rbel": "^1.0.1",
+    "url-listener": "^1.2.0",
     "xtend": "^4.0.1",
     "yo-yo": "^1.4.1"
   },

--- a/tests/testem.html
+++ b/tests/testem.html
@@ -3,19 +3,11 @@
 <head>
   <title>Test'em</title>
   <link rel="icon" type="image/png" href="tram-car.png" />
-  <script src="//cdnjs.cloudflare.com/ajax/libs/jasmine/1.3.1/jasmine.js"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.6.4/jasmine.min.css"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.6.4/jasmine.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.6.4/jasmine-html.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.6.4/boot.min.js"></script>
   <script src="/testem.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/jasmine/1.3.1/jasmine-html.js"></script>
-  <script>
-    (function() {
-      var jasmineEnv = jasmine.getEnv()
-      jasmineEnv.addReporter(new jasmine.HtmlReporter)
-
-      window.onload = function() {
-        jasmineEnv.execute()
-      };
-    })();
-  </script>
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/jasmine/1.3.1/jasmine.css">
 </head>
 <body>

--- a/tram-one.js
+++ b/tram-one.js
@@ -4,6 +4,7 @@ const belCreateElement = require('bel').createElement
 const rbelRegister = require('rbel')
 const minidux = require('minidux')
 const yoyoUpdate = require('yo-yo').update
+const urlListener = require('url-listener')
 
 class Tram {
   constructor(options) {
@@ -35,12 +36,20 @@ class Tram {
     return this
   }
 
+  dispatch(action) {
+    this.store.dispatch(action)
+  }
+
   start(selector, pathName) {
     const reducers = minidux.combineReducers(this.reducers)
     this.store = minidux.createStore(reducers, this.state)
 
     this.store.subscribe((state) => {
       this.mount(selector, pathName, state)
+    })
+
+    urlListener(() => {
+      this.mount(selector, pathName)
     })
 
     this.mount(selector, pathName, this.store.getState())


### PR DESCRIPTION
Resolves #3 
Start #8 

## changes
- update readme
- added url-listener package to handle push, pop, and hash events

## tests
- refactor tests to work with url-listener
- start should trigger the url-listener for popstates
- update jasmine version