### PR TITLE
Chrome Headless!

### DIFF
--- a/configs/testem.yml
+++ b/configs/testem.yml
@@ -1,7 +1,16 @@
 framework: jasmine
 launch_in_dev:
   - PhantomJS
+  - Chrome
   - Node
+browser_args:
+  Chrome:
+    mode: dev
+    args:
+      - --headless
+      - --disable-gpu
+      - --remote-debugging-port=9222
+      - --no-sandbox
 launchers:
   Node:
     command: npm run test-server


### PR DESCRIPTION
Adds chrome headless to the browsers run by default by testem.
Keeping PhantomJS because it mimics IE support fairly closely.